### PR TITLE
Changed the logic of upserting immunization services, #22

### DIFF
--- a/commcare-salesforce-jobs/Update-Person-in-SF-Production.js
+++ b/commcare-salesforce-jobs/Update-Person-in-SF-Production.js
@@ -607,11 +607,8 @@ steps(
   //** Immunization Services ************************************************//
   //BCG REVIEWED
   combine(function (state) {
-    if (
-      dataValue("$.form.TT5.Child_Information.Immunizations.copy-3-of-anc_3")(
-        state
-      ) == "click_to_enter_anc_3"
-    ) {
+    const { Immunizations } = state.data.form.TT5.Child_Information;
+    if (Immunizations && Immunizations.BCG_h && Immunizations.BCG_h === "") {
       upsert(
         "Service__c",
         "Service_UID__c",
@@ -652,10 +649,8 @@ steps(
   }),
   //OPV0 REVIEWED
   combine(function (state) {
-    if (
-      dataValue("$.form.TT5.Child_Information.Immunizations.anc_3")(state) ==
-      "click_to_enter_anc_3"
-    ) {
+    const { Immunizations } = state.data.form.TT5.Child_Information;
+    if (Immunizations && Immunizations.OPV0_h && Immunizations.OPV0_h === "") {
       upsert(
         "Service__c",
         "Service_UID__c",
@@ -696,11 +691,8 @@ steps(
   }),
   //OPV1 REVIEWED
   combine(function (state) {
-    if (
-      dataValue("$.form.TT5.Child_Information.Immunizations.copy-1-of-anc_3")(
-        state
-      ) == "click_to_enter_anc_3"
-    ) {
+    const { Immunizations } = state.data.form.TT5.Child_Information;
+    if (Immunizations && Immunizations.OPV1_h && Immunizations.OPV1_h === "") {
       upsert(
         "Service__c",
         "Service_UID__c",
@@ -743,11 +735,8 @@ steps(
   }),
   //OPV2
   combine(function (state) {
-    if (
-      dataValue("$.form.TT5.Child_Information.Immunizations.copy-2-of-anc_3")(
-        state
-      ) == "click_to_enter_anc_3"
-    ) {
+    const { Immunizations } = state.data.form.TT5.Child_Information;
+    if (Immunizations && Immunizations.OPV2_h && Immunizations.OPV2_h === "") {
       upsert(
         "Service__c",
         "Service_UID__c",
@@ -790,11 +779,8 @@ steps(
   }),
   //OPV3
   combine(function (state) {
-    if (
-      dataValue("$.form.TT5.Child_Information.Immunizations.copy-4-of-anc_3")(
-        state
-      ) == "click_to_enter_anc_3"
-    ) {
+    const { Immunizations } = state.data.form.TT5.Child_Information;
+    if (Immunizations && Immunizations.OPV3_h && Immunizations.OPV3_h === "") {
       upsert(
         "Service__c",
         "Service_UID__c",
@@ -837,10 +823,11 @@ steps(
   }),
   //Measles 6
   combine(function (state) {
+    const { Immunizations } = state.data.form.TT5.Child_Information;
     if (
-      dataValue("$.form.TT5.Child_Information.Immunizations.copy-5-of-anc_3")(
-        state
-      ) == "click_to_enter_anc_3"
+      Immunizations &&
+      Immunizations.Measles6_h &&
+      Immunizations.Measles6_h === ""
     ) {
       upsert(
         "Service__c",
@@ -882,10 +869,11 @@ steps(
   }),
   //Measles 9
   combine(function (state) {
+    const { Immunizations } = state.data.form.TT5.Child_Information;
     if (
-      dataValue("$.form.TT5.Child_Information.Immunizations.copy-6-of-anc_3")(
-        state
-      ) == "click_to_enter_anc_3"
+      Immunizations &&
+      Immunizations.Measles9_h &&
+      Immunizations.Measles9_h === ""
     ) {
       upsert(
         "Service__c",
@@ -928,10 +916,11 @@ steps(
 
   //Measles 18
   combine(function (state) {
+    const { Immunizations } = state.data.form.TT5.Child_Information;
     if (
-      dataValue("$.form.TT5.Child_Information.Immunizations.copy-7-of-anc_3")(
-        state
-      ) == "click_to_enter_anc_3"
+      Immunizations &&
+      Immunizations.Measles18_h &&
+      Immunizations.Measles18_h === ""
     ) {
       upsert(
         "Service__c",

--- a/commcare-salesforce-jobs/Update-Person-in-SF-Production.js
+++ b/commcare-salesforce-jobs/Update-Person-in-SF-Production.js
@@ -608,7 +608,7 @@ steps(
   //BCG REVIEWED
   combine(function (state) {
     const { Immunizations } = state.data.form.TT5.Child_Information;
-    if (Immunizations && Immunizations.BCG_h && Immunizations.BCG_h === "") {
+    if (Immunizations && Immunizations.BCG_h) {
       upsert(
         "Service__c",
         "Service_UID__c",
@@ -650,7 +650,7 @@ steps(
   //OPV0 REVIEWED
   combine(function (state) {
     const { Immunizations } = state.data.form.TT5.Child_Information;
-    if (Immunizations && Immunizations.OPV0_h && Immunizations.OPV0_h === "") {
+    if (Immunizations && Immunizations.OPV0_h) {
       upsert(
         "Service__c",
         "Service_UID__c",
@@ -692,7 +692,7 @@ steps(
   //OPV1 REVIEWED
   combine(function (state) {
     const { Immunizations } = state.data.form.TT5.Child_Information;
-    if (Immunizations && Immunizations.OPV1_h && Immunizations.OPV1_h === "") {
+    if (Immunizations && Immunizations.OPV1_h) {
       upsert(
         "Service__c",
         "Service_UID__c",
@@ -736,7 +736,7 @@ steps(
   //OPV2
   combine(function (state) {
     const { Immunizations } = state.data.form.TT5.Child_Information;
-    if (Immunizations && Immunizations.OPV2_h && Immunizations.OPV2_h === "") {
+    if (Immunizations && Immunizations.OPV2_h) {
       upsert(
         "Service__c",
         "Service_UID__c",
@@ -780,7 +780,7 @@ steps(
   //OPV3
   combine(function (state) {
     const { Immunizations } = state.data.form.TT5.Child_Information;
-    if (Immunizations && Immunizations.OPV3_h && Immunizations.OPV3_h === "") {
+    if (Immunizations && Immunizations.OPV3_h) {
       upsert(
         "Service__c",
         "Service_UID__c",
@@ -824,11 +824,7 @@ steps(
   //Measles 6
   combine(function (state) {
     const { Immunizations } = state.data.form.TT5.Child_Information;
-    if (
-      Immunizations &&
-      Immunizations.Measles6_h &&
-      Immunizations.Measles6_h === ""
-    ) {
+    if (Immunizations && Immunizations.Measles6_h) {
       upsert(
         "Service__c",
         "Service_UID__c",
@@ -870,11 +866,7 @@ steps(
   //Measles 9
   combine(function (state) {
     const { Immunizations } = state.data.form.TT5.Child_Information;
-    if (
-      Immunizations &&
-      Immunizations.Measles9_h &&
-      Immunizations.Measles9_h === ""
-    ) {
+    if (Immunizations && Immunizations.Measles9_h) {
       upsert(
         "Service__c",
         "Service_UID__c",
@@ -917,11 +909,7 @@ steps(
   //Measles 18
   combine(function (state) {
     const { Immunizations } = state.data.form.TT5.Child_Information;
-    if (
-      Immunizations &&
-      Immunizations.Measles18_h &&
-      Immunizations.Measles18_h === ""
-    ) {
+    if (Immunizations && Immunizations.Measles18_h) {
       upsert(
         "Service__c",
         "Service_UID__c",


### PR DESCRIPTION
The difference with ANC Services here is the different criteria can exist but be empty.
So we can find `Measles6_h: ""`

Thus using `if ( Measles6_h ){...}` is not enough we should also check if it existing but empty.