### PR TITLE
add cooldown

### DIFF
--- a/commcare-salesforce-jobs/upsert_household_and_household_visit.js
+++ b/commcare-salesforce-jobs/upsert_household_and_household_visit.js
@@ -4,6 +4,16 @@ query(
   )(state)}'`
 );
 
+fn(state => { console.log("query1 done"); return state; });
+fn(state => {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      console.log('4 second cooldown finished.');
+      resolve(state);
+    }, 4000);
+  });
+});
+
 fn(state => ({
   ...state,
   data: {
@@ -167,12 +177,24 @@ upsertIf(
     )
 );
 
+fn(state => { console.log("upsertIf1 done"); return state; });
+fn(state => {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      console.log('4 second cooldown finished.');
+      resolve(state);
+    }, 4000);
+  });
+});
+
 //Household Visit
 query(
   `SELECT Id, Parent_Geographic_Area__c, Parent_Geographic_Area__r.Name, Parent_Geographic_Area__r.Parent_Geographic_Area__c FROM Location__c WHERE CommCare_User_ID__c = '${dataValue(
     'properties.owner_id'
   )(state)}'`
 );
+
+fn(state => { console.log("query2 done"); return state; });
 
 fn(state => ({
   ...state,
@@ -390,4 +412,6 @@ upsertIf(
     })
   )
 );
+
+fn(state => { console.log("upsertIf2 done"); return state; });
 

--- a/commcare-salesforce-jobs/upsert_household_and_household_visit.js
+++ b/commcare-salesforce-jobs/upsert_household_and_household_visit.js
@@ -195,6 +195,14 @@ query(
 );
 
 fn(state => { console.log("query2 done"); return state; });
+fn(state => {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      console.log('4 second cooldown finished.');
+      resolve(state);
+    }, 4000);
+  });
+});
 
 fn(state => ({
   ...state,
@@ -414,4 +422,12 @@ upsertIf(
 );
 
 fn(state => { console.log("upsertIf2 done"); return state; });
+fn(state => {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      console.log('Final 4 second cooldown finished.');
+      resolve(state);
+    }, 4000);
+  });
+});
 


### PR DESCRIPTION
@aleksa-krolls suggested that maybe these requests are going _too fast_ for Salesforce's API. If we're not in danger of running into OpenFn runtime limits (100s) then why not slow down the requests to Salesforce with a cooldown?

This is an attempt to fix #86 