### PR TITLE
Reduce final state for `bulk/bulkGetCases-HH.js` job 

### DIFF
--- a/bulk/bulkGetCases-HH.js
+++ b/bulk/bulkGetCases-HH.js
@@ -4,7 +4,7 @@ fn(state => {
   const caseTypes = ['Household'];
 
   //NOTE: You can use 'limit' to modify this batch size as desired
-  const limit = 1000; 
+  const limit = 1000;
 
   //NOTE: indexedOnStart is the default sync start data the FIRST time the job runs
   const indexedOnStart = '2023-01-15T10:00:00';
@@ -13,13 +13,14 @@ fn(state => {
   const lastRunAt =
     typeof state.lastRunAt !== 'undefined' ? state.lastRunAt : indexedOnStart;
   console.log('Filtering cases with indexed_on_start > than ::', lastRunAt);
-//May 31st, 2023 at 3:00:13 PM.
+  //May 31st, 2023 at 3:00:13 PM.
   const queries = caseTypes.map(
-   // t => `?type=${t}&indexed_on_start=${lastRunAt}&limit=${limit}`
+    // t => `?type=${t}&indexed_on_start=${lastRunAt}&limit=${limit}`
     //NOTE: If for testing, you want to fetch data for a specific historical range (e.g., between April 23 and 24)...
     //...then use the query string below instead of the one above on L16, and custom adjust the index_on start/end dates
     //t => `?type=${t}&indexed_on_start=2023-03-03T00:00:00&limit=${limit}&indexed_on_end=2023-03-06T00:00:00` //returns 14 records
-    t => `?type=${t}&indexed_on_start=2023-01-11T14:00:00&limit=${limit}&indexed_on_end=2023-01-13T17:30:00` 
+    t =>
+      `?type=${t}&indexed_on_start=2023-01-11T14:00:00&limit=${limit}&indexed_on_end=2023-01-13T17:30:00`
   );
 
   return { ...state, queries, baseUrl, payloads: [] };
@@ -69,5 +70,5 @@ each(
 fn(state => {
   console.log('Count of payloads', state.payloads.length);
 
-  return { ...state, references: [], data: {} };
+  return { ...state, references: [], data: {}, response: {} };
 });


### PR DESCRIPTION
### Summary 

Reduce final state for `bulk/bulkGetCases-HH.js` job by removing  the content of `state.response`